### PR TITLE
Update RichText component for rich text editing support

### DIFF
--- a/resources/views/richtext.blade.php
+++ b/resources/views/richtext.blade.php
@@ -4,3 +4,24 @@
     'options' => [],
 ])
 <textarea {{ $attributes->merge(['class' => 'textarea'.($hasError ? ' textarea-error' : '')]) }}>{{ $value ?: $slot }}</textarea>
+
+@props([
+    'hasError' => false,
+    'value' => '',
+    'options' => [],
+    'quillUniq' => 'quill'
+])
+<div
+     {{ $attributes->merge(['class' => ($hasError ? ' textarea-error' : '' }}
+     x-data="quill({
+__value: @entangle($attributes->wire('model')),
+options: {{ $options }},
+__config(instance, quillOptions) {
+return { {{ $config ?? '' }} };
+},
+})"
+     x-cloak
+>
+
+    <div x-ref="quill">{{ $value ?: $slot }}</div>
+</div>


### PR DESCRIPTION
RichText component has been updated to add support for rich text editing using Quill.js. With this integration, users are provided an enhanced editing experience, allowing for more precise content formation. Users can apply this feature by linking the RichText component with a unique 'quillUniq' identifier.