### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/step2dev/lazy-ui/security/code-scanning/2](https://github.com/step2dev/lazy-ui/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents (e.g., to check out code), we can set `contents: read` as the minimal permission. This will restrict the workflow's access to only what is necessary for its operation.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs within the workflow. No additional imports, methods, or definitions are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
