### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,5 +1,8 @@
 name: PHPStan
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/step2dev/lazy-ui/security/code-scanning/1](https://github.com/step2dev/lazy-ui/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out code and runs PHPStan, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
